### PR TITLE
Add Tarot Spread Reading Component and Enhance Tarot Layouts

### DIFF
--- a/src/lib/components/tarot/TarotSpreadReading.svelte
+++ b/src/lib/components/tarot/TarotSpreadReading.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+  import type { TarotLayout, DrawnCard } from '$lib/data/tarot-layouts';
+  import * as Dialog from '$lib/components/ui/dialog';
+
+  interface Props {
+    layout: TarotLayout;
+    drawnCards: DrawnCard[];
+  }
+
+  let { layout, drawnCards }: Props = $props();
+
+  let selectedCard: DrawnCard | null = $state(null);
+  let cardModalOpen = $state(false);
+
+  $: bounds = (() => {
+    if (drawnCards.length === 0) return { maxX: 600, maxY: 400 };
+    let maxX = 0;
+    let maxY = 0;
+    for (const { position } of drawnCards) {
+      maxX = Math.max(maxX, position.x + position.width);
+      maxY = Math.max(maxY, position.y + position.height);
+    }
+    return { maxX: Math.max(maxX, 600), maxY: Math.max(maxY, 400) };
+  })();
+
+  function openCardDetail(dc: DrawnCard) {
+    selectedCard = dc;
+    cardModalOpen = true;
+  }
+
+  function closeCardDetail() {
+    selectedCard = null;
+    cardModalOpen = false;
+  }
+</script>
+
+<div class="spread-reading">
+  <div
+    class="spread-container"
+    style="aspect-ratio: {bounds.maxX} / {bounds.maxY}; max-width: 100%;"
+  >
+    {#each drawnCards as drawn}
+      {@const p = drawn.position}
+      {@const leftPct = (p.x / bounds.maxX) * 100}
+      {@const topPct = (p.y / bounds.maxY) * 100}
+      {@const widthPct = (p.width / bounds.maxX) * 100}
+      {@const heightPct = (p.height / bounds.maxY) * 100}
+      <button
+        type="button"
+        class="spread-card-slot"
+        style="
+          left: {leftPct}%;
+          top: {topPct}%;
+          width: {widthPct}%;
+          height: {heightPct}%;
+        "
+        on:click={() => openCardDetail(drawn)}
+      >
+        <div class="card-image-wrap" class:reversed={drawn.reversed}>
+          <img
+            src={drawn.card.image}
+            alt={drawn.card.name}
+          />
+        </div>
+        <span class="position-number">{p.number}</span>
+        <span class="position-name">{p.name}</span>
+      </button>
+    {/each}
+  </div>
+
+  <ul class="position-list" aria-label="Cards in this spread">
+    {#each drawnCards as drawn}
+      <li>
+        <button
+          type="button"
+          class="position-list-item"
+          on:click={() => openCardDetail(drawn)}
+        >
+          <span class="position-num">{drawn.position.number}.</span>
+          <span class="position-title">{drawn.position.name}</span>
+          <span class="card-name">{drawn.card.name}{drawn.reversed ? ' (Reversed)' : ''}</span>
+        </button>
+      </li>
+    {/each}
+  </ul>
+</div>
+
+{#if selectedCard}
+  <Dialog.Root bind:open={cardModalOpen}>
+    <Dialog.Content class="max-w-2xl max-h-[90vh] overflow-y-auto">
+      <Dialog.Header>
+        <Dialog.Title>
+          Position {selectedCard.position.number}: {selectedCard.position.name}
+        </Dialog.Title>
+        <Dialog.Description>
+          {selectedCard.card.name}{selectedCard.reversed ? ' (Reversed)' : ''}
+          {#if selectedCard.card.suit}
+            — {selectedCard.card.suit}
+          {/if}
+        </Dialog.Description>
+      </Dialog.Header>
+      <div class="flex gap-4 items-start mt-4">
+        <div class="shrink-0">
+          <div
+            class="card-image-wrap rounded-lg overflow-hidden"
+            class:reversed={selectedCard.reversed}
+            style="max-width: 160px;"
+          >
+            <img
+              src={selectedCard.card.image}
+              alt={selectedCard.card.name}
+              class="w-full h-auto block"
+            />
+          </div>
+        </div>
+        <div class="min-w-0 space-y-3">
+          <p class="text-sm text-gray-600">{selectedCard.position.description}</p>
+          <div>
+            <h4 class="text-sm font-semibold text-gray-900 mb-1">Meaning</h4>
+            <p class="text-sm text-gray-700">
+              {selectedCard.reversed
+                ? selectedCard.card.reversed.general
+                : selectedCard.card.upright.general}
+            </p>
+          </div>
+          <div class="flex flex-wrap gap-1">
+            {#each selectedCard.card.keywords as keyword}
+              <span class="bg-purple-100 text-purple-800 px-2 py-0.5 rounded text-xs">
+                {keyword}
+              </span>
+            {/each}
+          </div>
+        </div>
+      </div>
+    </Dialog.Content>
+  </Dialog.Root>
+{/if}
+
+<style>
+  .spread-reading {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .spread-container {
+    position: relative;
+    width: 100%;
+    margin: 0 auto;
+    background: linear-gradient(145deg, #f5f3ff 0%, #ede9fe 100%);
+    border-radius: 12px;
+    border: 1px solid #e9e5ff;
+    min-height: 280px;
+  }
+
+  .spread-card-slot {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    padding: 4px;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.15s ease;
+    border-radius: 8px;
+  }
+
+  .spread-card-slot:hover {
+    transform: scale(1.03);
+  }
+
+  .spread-card-slot:focus-visible {
+    outline: 2px solid #7c3aed;
+    outline-offset: 2px;
+  }
+
+  .card-image-wrap {
+    width: 100%;
+    flex: 1;
+    min-height: 0;
+    border-radius: 6px;
+    overflow: hidden;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .card-image-wrap img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .card-image-wrap.reversed img {
+    transform: rotate(180deg);
+  }
+
+  .position-number {
+    position: absolute;
+    top: 6px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(124, 58, 237, 0.9);
+    color: white;
+    width: 1.25rem;
+    height: 1.25rem;
+    border-radius: 50%;
+    font-size: 0.7rem;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .position-name {
+    margin-top: 2px;
+    font-size: 0.6rem;
+    font-weight: 600;
+    color: #4b5563;
+    text-align: center;
+    line-height: 1.1;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .position-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .position-list-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: white;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    cursor: pointer;
+    text-align: left;
+    width: 100%;
+    font-size: 0.875rem;
+    transition: background 0.15s, border-color 0.15s;
+  }
+
+  .position-list-item:hover {
+    background: #f5f3ff;
+    border-color: #c4b5fd;
+  }
+
+  .position-num {
+    font-weight: 700;
+    color: #7c3aed;
+    min-width: 1.5rem;
+  }
+
+  .position-title {
+    font-weight: 600;
+    color: #374151;
+    min-width: 8rem;
+  }
+
+  .card-name {
+    color: #6b7280;
+    margin-left: auto;
+  }
+
+  @media (min-width: 640px) {
+    .position-name {
+      font-size: 0.65rem;
+    }
+  }
+</style>

--- a/src/lib/data/tarot-layouts.ts
+++ b/src/lib/data/tarot-layouts.ts
@@ -5,6 +5,7 @@ import {
   generateCareerPathSVG, 
   generateSpiritualJourneySVG 
 } from '$lib/utils/tarot-svg-generator';
+import { ALL_TAROT_CARDS, type TarotCard } from '$lib/data/tarot-data';
 
 export interface TarotLayout {
   id: string;
@@ -28,6 +29,42 @@ export interface LayoutPosition {
   y: number;
   width: number;
   height: number;
+}
+
+export interface DrawnCard {
+  position: LayoutPosition;
+  card: TarotCard;
+  reversed: boolean;
+}
+
+/**
+ * Fisher–Yates shuffle (mutates array).
+ */
+function shuffleArray<T>(array: T[]): T[] {
+  const result = [...array];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/**
+ * Draw cards for a given spread. Shuffles the full deck and assigns cards to positions.
+ * Each card has a 50% chance of being reversed.
+ */
+export function drawCardsForSpread(
+  layout: TarotLayout,
+  options?: { allowReversed?: boolean }
+): DrawnCard[] {
+  const allowReversed = options?.allowReversed !== false;
+  const shuffled = shuffleArray(ALL_TAROT_CARDS);
+  const positions = [...layout.positions].sort((a, b) => a.number - b.number);
+  return positions.map((position, index) => {
+    const card = shuffled[index];
+    const reversed = allowReversed && Math.random() < 0.5;
+    return { position, card, reversed };
+  });
 }
 
 export const TAROT_LAYOUTS: TarotLayout[] = [

--- a/src/routes/tarot-layouts/+page.svelte
+++ b/src/routes/tarot-layouts/+page.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-
   import * as Input from '$lib/components/ui/input';
   import * as Dialog from '$lib/components/ui/dialog';
-  import { TAROT_LAYOUTS, type TarotLayout, getAllCategories, getAllDifficulties } from '$lib/data/tarot-layouts';
+  import * as Button from '$lib/components/ui/button';
+  import { TAROT_LAYOUTS, type TarotLayout, type DrawnCard, drawCardsForSpread } from '$lib/data/tarot-layouts';
+  import TarotSpreadReading from '$lib/components/tarot/TarotSpreadReading.svelte';
 
   let searchTerm = '';
   let selectedCategory = 'all';
   let selectedDifficulty = 'all';
   let selectedLayout: TarotLayout | null = null;
   let modalOpen = false;
+  let drawnCards: DrawnCard[] = [];
 
   const categories = [
     { value: 'all', label: 'All Categories' },
@@ -49,12 +50,20 @@
 
   function selectLayout(layout: TarotLayout) {
     selectedLayout = layout;
+    drawnCards = [];
     modalOpen = true;
   }
 
   function closeLayoutDetail() {
     selectedLayout = null;
+    drawnCards = [];
     modalOpen = false;
+  }
+
+  function pullCards() {
+    if (selectedLayout) {
+      drawnCards = drawCardsForSpread(selectedLayout);
+    }
   }
 
   function getDifficultyColor(difficulty: string) {
@@ -270,6 +279,28 @@
           </Dialog.Description>
         </Dialog.Header>
         
+        <!-- Pull cards / Reading section -->
+        <div class="mb-6">
+          {#if drawnCards.length > 0}
+            <div class="flex items-center justify-between mb-4">
+              <h3 class="text-lg font-semibold text-gray-900">Your reading</h3>
+              <Button.Root on:click={pullCards} variant="outline" size="sm">
+                Draw again
+              </Button.Root>
+            </div>
+            <TarotSpreadReading layout={selectedLayout} drawnCards={drawnCards} />
+          {:else}
+            <div class="bg-purple-50 border border-purple-200 rounded-lg p-4 mb-6">
+              <p class="text-sm text-purple-800 mb-3">
+                Pull cards for this spread to see a random reading. Cards are drawn from the full deck; each may appear upright or reversed.
+              </p>
+              <Button.Root on:click={pullCards} class="bg-purple-600 hover:bg-purple-700 text-white">
+                Pull cards for this spread
+              </Button.Root>
+            </div>
+          {/if}
+        </div>
+
         <div class="grid grid-cols-1 lg:grid-cols-[1fr_1.2fr] gap-8 my-6">
           <!-- Layout Visualization -->
           <div class="space-y-6">

--- a/src/routes/tarot/+page.svelte
+++ b/src/routes/tarot/+page.svelte
@@ -143,8 +143,8 @@
       </div>
     </div>
 
-    <!-- Add this button somewhere prominent in the tarot page -->
-    <div class="flex justify-center mb-6">
+    <!-- Spreads & pull cards -->
+    <div class="flex flex-wrap justify-center gap-4 mb-6">
       <a 
         href="/tarot-layouts" 
         class="inline-flex items-center gap-2 bg-gradient-to-r from-purple-600 to-indigo-600 text-white px-6 py-3 rounded-lg font-medium hover:from-purple-700 hover:to-indigo-700 transition-all duration-200 transform hover:scale-105 shadow-lg"
@@ -153,6 +153,15 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
         </svg>
         Explore Tarot Layouts
+      </a>
+      <a 
+        href="/tarot-layouts" 
+        class="inline-flex items-center gap-2 bg-white border-2 border-purple-600 text-purple-700 px-6 py-3 rounded-lg font-medium hover:bg-purple-50 transition-all duration-200 shadow-md"
+      >
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14" />
+        </svg>
+        Pull cards for a spread
       </a>
     </div>
 


### PR DESCRIPTION
- Introduced the `TarotSpreadReading` component to display drawn cards in a visual spread format, allowing users to interact with their tarot readings.
- Updated `tarot-layouts.ts` to include functionality for drawing cards, incorporating a shuffle mechanism and support for reversed cards.
- Enhanced the tarot layouts page to facilitate card pulling, providing users with a seamless experience to generate random readings.
- Improved UI elements for better accessibility and user engagement, including a new button for pulling cards and a modal for displaying card details.